### PR TITLE
Load non-default Prism language components on first use.

### DIFF
--- a/src/syntaxHighlightPrism.js
+++ b/src/syntaxHighlightPrism.js
@@ -5,6 +5,9 @@ module.exports = function(liquidEngine) {
   let highlight = new LiquidHighlight(liquidEngine);
 
   highlight.addHook(function(language, htmlStr, lines) {
+    if (! Prism.languages[ language ]) {
+      require(`prismjs/components/prism-${language}`);      
+    }
     return Prism.highlight(htmlStr, Prism.languages[ language ]);
   });
 


### PR DESCRIPTION
Prism syntax highlighting was only working for the default languages (AFAICT).  This attempts to load a corresponding prism component when an unknown language is first encountered.