### PR TITLE
Support multiple consecutive line breaks in code snippets

### DIFF
--- a/src/markdownSyntaxHighlight.js
+++ b/src/markdownSyntaxHighlight.js
@@ -37,7 +37,7 @@ module.exports = function(str, language) {
       (highlights.isHighlightedAdd(j) ? " highlight-line-add" : "") +
       (highlights.isHighlightedRemove(j) ? " highlight-line-remove" : "") +
       "\">" +
-      (line || '\n') +
+      (line || '\n') + // https://github.com/11ty/eleventy-plugin-syntaxhighlight/pull/5
       "</div>";
   });
 

--- a/src/markdownSyntaxHighlight.js
+++ b/src/markdownSyntaxHighlight.js
@@ -26,20 +26,16 @@ module.exports = function(str, language) {
 
   let highlights = new HighlightLinesGroup(split.join("/"), "/");
 
-  let lines = html.split("\n");
+  let lines = html.split("\n").slice(0, -1); // The last line is empty.
   let highlightedLines = lines.map(function(line, j) {
-    if( j + 1 === lines.length ) {
-      return "";
-    }
-
-    return "<div class=\"highlight-line" +
+    return "<span class=\"highlight-line" +
       (highlights.isHighlighted(j) ? " highlight-line-active" : "") +
       (highlights.isHighlightedAdd(j) ? " highlight-line-add" : "") +
       (highlights.isHighlightedRemove(j) ? " highlight-line-remove" : "") +
       "\">" +
-      (line || '\n') + // https://github.com/11ty/eleventy-plugin-syntaxhighlight/pull/5
-      "</div>";
+      line +
+      "</span>";
   });
 
-  return `<pre class="language-${language}"><code class="language-${language}">${highlightedLines.join("")}</code></pre>`;
+  return `<pre class="language-${language}"><code class="language-${language}">${highlightedLines.join("<br>")}</code></pre>`;
 };

--- a/src/markdownSyntaxHighlight.js
+++ b/src/markdownSyntaxHighlight.js
@@ -37,7 +37,7 @@ module.exports = function(str, language) {
       (highlights.isHighlightedAdd(j) ? " highlight-line-add" : "") +
       (highlights.isHighlightedRemove(j) ? " highlight-line-remove" : "") +
       "\">" +
-      line +
+      (line || '\n') +
       "</div>";
   });
 


### PR DESCRIPTION
Previously, repeated consecutive line breaks got eaten by this syntax highlighter plugin.

Consider this imaginary code snippet:

    ```
    foo

    bar
    ```

The empty line got turned into an empty `<div class="highlight-line"></div>`, which is a form of data loss — the actual line break is no longer part of the resulting HTML. This caused it to render differently, too.

This patch ensures newlines are preserved by explicitly inserting them in the resulting HTML ~~when needed~~ <u>consistently</u>.