### PR TITLE
Add support for line numbers

### DIFF
--- a/src/LineNumbers.js
+++ b/src/LineNumbers.js
@@ -1,0 +1,15 @@
+function LineNumbers(lineCount) {
+  let lineNumbersWrapper = "";
+  if (!lineCount) {
+    return "";
+  }
+
+  const linesNum = lineCount;
+
+  const lines = new Array(linesNum + 1).join("<span></span>");
+  lineNumbersWrapper = `<span aria-hidden="true" class="line-numbers-rows">${lines}</span>`;
+
+  return lineNumbersWrapper;
+}
+
+module.exports = LineNumbers;

--- a/src/LineNumbers.js
+++ b/src/LineNumbers.js
@@ -1,7 +1,7 @@
 function LineNumbers(lineCount) {
   let lineNumbersWrapper = "";
   if (!lineCount) {
-    return "";
+    return lineNumbersWrapper;
   }
 
   const linesNum = lineCount;

--- a/src/markdownSyntaxHighlight.js
+++ b/src/markdownSyntaxHighlight.js
@@ -1,6 +1,7 @@
 const Prism = require("prismjs");
 const PrismLoader = require("prismjs/components/index.js");
 const HighlightLinesGroup = require("./HighlightLinesGroup");
+const LineNumbers = require("./LineNumbers");
 
 module.exports = function(str, language) {
   if(!language) {
@@ -31,5 +32,15 @@ module.exports = function(str, language) {
     return highlights.getLineMarkup(j, line);
   });
 
-  return `<pre class="language-${language}"><code class="language-${language}">${highlightedLines.join("<br>")}</code></pre>`;
+
+  // Not sure how to configure this on/off
+  const numberLines = LineNumbers(highlightedLines.length);
+  const preClasses = [
+    `language-${language}`,
+  ];
+  if (numberLines !== "") {
+    preClasses.push("line-numbers");
+  }
+
+  return `<pre class="${preClasses.join(" ")}"><code class="language-${language}">${highlightedLines.join("<br>")}${numberLines}</code></pre>`;
 };


### PR DESCRIPTION
I have tried for a while to use the line numbers plugin provided by Prism in Eleventy. But it's to heavily dependent on the browser so it's not possible.

Next I tried to create a plugin that could be used in plugin options for this one. But that also was unsuccessful because of the limited Prism hooks that are used by node.js.

So then I looked at original line numbers plugin and came up with this solution to add support in Eleventy.

The function `LineNumbers` tries to do the same as the original Prism plugin, it creates a `<span>` with a span per line as children.

Then I tweaked `markdownSyntaxHighlight.js` to use it and append the spans to the code.

This works really good with the CSS from Prism:
``` scss
.line-numbers {
  .line-numbers-rows {
    position: absolute;
    pointer-events: none;
    top: 0;
    font-size: 100%;
    left: -3.8em;
    width: 3em;
    letter-spacing: -1px;
    border-right: 1px solid #999;
    -webkit-user-select: none;
    -moz-user-select: none;
    -ms-user-select: none;
    user-select: none;
  }
  .line-numbers-rows > span {
    pointer-events: none;
    display: block;
    counter-increment: linenumber;
  }
  .line-numbers-rows > span::before {
    content: counter(linenumber);
    color: #999;
    display: block;
    padding-right: 0.8em;
    text-align: right;
}
}
pre[class*="language-"].line-numbers {
  position: relative;
  padding-left: 3.8em;
  counter-reset: linenumber;
}
pre[class*="language-"].line-numbers > code {
  position: relative;
  white-space: inherit;
}
```

Example:
![Eleventy_Essentials___Andeers_com](https://user-images.githubusercontent.com/2273311/59026197-1b69e300-8856-11e9-90b5-d2e2db2b1af5.png)

I'm not sure if this is the best approach, and I'm not sure what the best way to make it optional is. But I figured it was easier to create this PR to show my solution. It would fix #10.