### PR TITLE
update ava 2.4 => 3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@11ty/eleventy": ">=0.5.4"
   },
   "devDependencies": {
-    "ava": "^2.4.0",
-    "@11ty/eleventy": "^0.9.0"
+    "@11ty/eleventy": "^0.10.0",
+    "ava": "^3.5.0"
   },
   "dependencies": {
     "prismjs": "^1.17.1"

--- a/test/HasTemplateFormatTest.js
+++ b/test/HasTemplateFormatTest.js
@@ -1,5 +1,5 @@
-import test from "ava";
-import hasTemplateFormat from "../src/hasTemplateFormat";
+const test = require("ava");
+const hasTemplateFormat = require("../src/hasTemplateFormat");
 
 test("hasTemplateFormats", t => {
   t.true(hasTemplateFormat("*", "liquid"));

--- a/test/HighlightLinesGroupTest.js
+++ b/test/HighlightLinesGroupTest.js
@@ -1,5 +1,5 @@
-import test from "ava";
-import HighlightLinesGroup from "../src/HighlightLinesGroup";
+const test = require("ava");
+const HighlightLinesGroup = require("../src/HighlightLinesGroup");
 
 test("Empty", t => {
   let hilite = new HighlightLinesGroup("");

--- a/test/HighlightLinesTest.js
+++ b/test/HighlightLinesTest.js
@@ -1,5 +1,5 @@
-import test from "ava";
-import HighlightLines from "../src/HighlightLines";
+const test = require("ava");
+const HighlightLines = require("../src/HighlightLines");
 
 test("HighlightLines empty", t => {
   let hilite = new HighlightLines("");

--- a/test/HighlightPairedShortcodeTest.js
+++ b/test/HighlightPairedShortcodeTest.js
@@ -1,5 +1,5 @@
-import test from "ava";
-import HighlightPairedShortcode from "../src/HighlightPairedShortcode";
+const test = require("ava");
+const HighlightPairedShortcode = require("../src/HighlightPairedShortcode");
 
 test("Base", async t => {
   t.is(await HighlightPairedShortcode(`alert();

--- a/test/MarkdownHighlightTest.js
+++ b/test/MarkdownHighlightTest.js
@@ -1,6 +1,6 @@
-import test from "ava";
-import md from "markdown-it";
-import markdownPrismJsOptions from "../src/markdownSyntaxHighlightOptions";
+const test = require("ava");
+const md = require("markdown-it");
+const markdownPrismJsOptions = require("../src/markdownSyntaxHighlightOptions");
 
 test("Test Markdown Highlighter", t => {
   let mdLib = md();


### PR DESCRIPTION
ava 2.4 => 3.5
eleventy 0.9.0 => 0.10.0
update tests to use CJS instead of ESM

Between ava 2.4 and ava 3.0, they changed best practices from ESM style imports to CJS style requires 🤷‍♂ 