### PR TITLE
Fix table rendering when lines are highlighted

### DIFF
--- a/demo/test-markdown.md
+++ b/demo/test-markdown.md
@@ -34,6 +34,30 @@ let multilineString = `
 `;
 ```
 
+## Table
+
+no highlights
+
+``` markdown
+| State         | Capital |
+| :------------ | :------ |
+| New York      | Albany  |
+| Nebraska      | Lincoln |
+| New Hampshire | Concord |
+```
+
+markdown/3
+
+``` markdown/3
+| State         | Capital |
+| :------------ | :------ |
+| New York      | Albany  |
+| Nebraska      | Lincoln |
+| New Hampshire | Concord |
+```
+
+
+
 ## Dash line
 
 ```js/-

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -21,9 +21,26 @@ module.exports = function(options = {}) {
       html = Prism.highlight(str, PrismLoader(language), language);
     }
 
+        //  Prism's markdown highlighter renders tables
+        //  with a newline before the end of the corresponding
+        //  markdown line. It's hacky, but I'd rather
+        //  fix it up here than figure out how to
+        //  fix Prism's markdown highlighter
+
+    if(language === 'markdown'){
+      let wickedPattern=/<\/span>\n<\/span>/g
+      let goodReplacement='</span></span>\n'
+      html = html.replace(wickedPattern, goodReplacement)
+    }
+
     let hasHighlightNumbers = split.length > 0;
     let highlights = new HighlightLinesGroup(split.join("/"), "/");
-    let lines = html.split("\n").slice(0, -1); // The last line is empty.
+
+    let lines = html.split("\n")
+      //  The last line is usually empty
+      //  but not always -- such as tables
+    if (lines[lines.length-1] === "")
+      lines.pop()
 
     lines = lines.map(function(line, j) {
       if(options.alwaysWrapLineHighlights || hasHighlightNumbers) {


### PR DESCRIPTION
Because of the way Prism renders Markdown tables, things get screwed up because the plugin expects that a `\n` ends the table line, so the markup wrappers end up in a strange place. Without highlighting, things look good, but with highlights, the spacing is all weird.

<img width="1221" alt="Screen Shot 2020-05-09 at 10 24 41 PM" src="https://user-images.githubusercontent.com/113034/81489628-ecb67280-9245-11ea-9299-97a92368d1e4.png">


After hacking the Prism output a tad, things are better. We change
`<\/span>\n<\/span>`
to
`</span></span>\n`


<img width="1221" alt="Screen Shot 2020-05-09 at 10 26 43 PM" src="https://user-images.githubusercontent.com/113034/81489655-24251f00-9246-11ea-9e20-30dae54770e2.png">

