### PR TITLE
Allow project-global default/fallback language

### DIFF
--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -4,6 +4,8 @@ const HighlightLinesGroup = require("./HighlightLinesGroup");
 
 module.exports = function(options = {}) {
   return function(str, language) {
+    language = language || options.defaultLanguage;
+
     if(!language) {
       // empty string means defer to the upstream escaping code built into markdown lib.
       return "";


### PR DESCRIPTION
This allows config like eleventyConfig.addPlugin(syntaxHighlight, { defaultLanguage: "text" }).

I mainly want this so that I can have the same HTML structure for all code blocks, whether or not they are highlighted. This lets me apply CSS uniformly.

This change should be backwards-compatible. If no language is specified, it behaves as before, skipping highlighting.