### PR TITLE
Add language name as data-attribute

### DIFF
--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -1,4 +1,5 @@
 const Prism = require("prismjs");
+const PrismLanguages = require("prismjs/components.js").languages;
 const PrismLoader = require("./PrismLoader");
 const HighlightLinesGroup = require("./HighlightLinesGroup");
 const getAttributes = require("./getAttributes");
@@ -37,6 +38,6 @@ module.exports = function (options = {}) {
       return line;
     });
 
-    return `<pre class="language-${language}"${preAttributes}><code class="language-${language}"${codeAttributes}>${lines.join(options.lineSeparator || "<br>")}</code></pre>`;
+    return `<pre data-language-name="${PrismLanguages[language].title}" class="language-${language}"${preAttributes}><code class="language-${language}"${codeAttributes}>${lines.join(options.lineSeparator || "<br>")}</code></pre>`;
   };
 };


### PR DESCRIPTION
Allows displaying highlight language name as a hint, e.g.:

```css
pre[class*="language-"]::before {
  content:attr(data-language-name);
  display: inline-block;
  position: absolute;
  top: 0;
  right: 0;
  padding: 4px 10px 2px;
  background-color: #e6e6e6;
  border-bottom: 1px solid #dddddd;
  border-left: 1px solid #dddddd;
  border-bottom-left-radius: 6px;
  font-size: 0.75em;
}
```

results in:

<img width="591" alt="" src="https://user-images.githubusercontent.com/153481/154703654-af0306ed-cd50-4ac5-833a-bce265336abb.png">
