### PR TITLE
Feature: Add option to ignore languages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -20,7 +20,8 @@ module.exports = {
       // eligible to change the default to \n in a new major version.
       lineSeparator: "<br>",
       preAttributes: {},
-      codeAttributes: {}
+      codeAttributes: {},
+      languageFilter: []
     }, options);
 
     // TODO hbs?

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,7 +21,7 @@ module.exports = {
       lineSeparator: "<br>",
       preAttributes: {},
       codeAttributes: {},
-      languageFilter: []
+      filterLanguages: []
     }, options);
 
     // TODO hbs?

--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -14,7 +14,7 @@ module.exports = function (content, language, highlightNumbers, options = {}) {
   }
 
   if (filterLanguages.includes(language)) {
-    return `<pre class="${language} language-filtered no-highlight">${preAttributes}>
+    return `<pre class="${language} language-filtered no-highlight" ${preAttributes}>
   ${content}
   </pre>`;
   }

--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -14,7 +14,9 @@ module.exports = function (content, language, highlightNumbers, options = {}) {
   }
 
   if (filterLanguages.includes(language)) {
-    return `<pre class="${language} language-filtered no-highlight">${preAttributes}>${content}</pre>`;
+    return `<pre class="${language} language-filtered no-highlight">${preAttributes}>
+  ${content}
+  </pre>`;
   }
 
   let highlightedContent;

--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -6,10 +6,15 @@ const getAttributes = require("./getAttributes");
 module.exports = function (content, language, highlightNumbers, options = {}) {
   const preAttributes = getAttributes(options.preAttributes);
   const codeAttributes = getAttributes(options.codeAttributes);
+  const filterLanguages = getAttributes(options.filterLanguages);
 
   // default to on
   if(options.trim === undefined || options.trim === true) {
     content = content.trim();
+  }
+
+  if (filterLanguages.includes(language)) {
+    return `<pre class="${language} language-filtered no-highlight">${preAttributes}>${content}</pre>`;
   }
 
   let highlightedContent;

--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -6,7 +6,7 @@ const getAttributes = require("./getAttributes");
 module.exports = function (content, language, highlightNumbers, options = {}) {
   const preAttributes = getAttributes(options.preAttributes);
   const codeAttributes = getAttributes(options.codeAttributes);
-  const filterLanguages = getAttributes(options.filterLanguages);
+  const filterLanguages = options.filterLanguages || [];
 
   // default to on
   if(options.trim === undefined || options.trim === true) {

--- a/src/getAttributes.js
+++ b/src/getAttributes.js
@@ -27,6 +27,11 @@ function getAttributes(attributes) {
   if (!attributes) {
     return "";
   } else if (typeof attributes === "object") {
+
+    if (attributes.map !== undefined) {
+      return attributes;
+    }
+
     const formattedAttributes = Object.entries(attributes).map(
       attributeEntryToString
     );

--- a/src/getAttributes.js
+++ b/src/getAttributes.js
@@ -27,11 +27,6 @@ function getAttributes(attributes) {
   if (!attributes) {
     return "";
   } else if (typeof attributes === "object") {
-
-    if (attributes.map !== undefined) {
-      return attributes;
-    }
-
     const formattedAttributes = Object.entries(attributes).map(
       attributeEntryToString
     );

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -20,7 +20,7 @@ module.exports = function (options = {}) {
     }
 
     if (filterLanguages.includes(language)) {
-      return `<pre class="${language} language-filtered no-highlight">${preAttributes}>
+      return `<pre class="${language} language-filtered no-highlight" ${preAttributes}>
   ${str}
   </pre>`;
     }

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -6,7 +6,7 @@ const getAttributes = require("./getAttributes");
 module.exports = function (options = {}) {
   const preAttributes = getAttributes(options.preAttributes);
   const codeAttributes = getAttributes(options.codeAttributes);
-  const filterLanguages = getAttributes(options.filterLanguages);
+  const filterLanguages = options.filterLanguages || [];
 
   return function(str, language) {
     if(!language) {

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -19,7 +19,7 @@ module.exports = function (options = {}) {
       language = split.shift();
     }
 
-    if(filterLanguages.includes(language)) {
+    if (filterLanguages.includes(language)) {
       return `<pre class="${language} language-filtered no-highlight">${preAttributes}>${str}</pre>`;
     }
 

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -20,7 +20,9 @@ module.exports = function (options = {}) {
     }
 
     if (filterLanguages.includes(language)) {
-      return `<pre class="${language} language-filtered no-highlight">${preAttributes}>${str}</pre>`;
+      return `<pre class="${language} language-filtered no-highlight">${preAttributes}>
+  ${str}
+  </pre>`;
     }
 
     let html;

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -6,6 +6,7 @@ const getAttributes = require("./getAttributes");
 module.exports = function (options = {}) {
   const preAttributes = getAttributes(options.preAttributes);
   const codeAttributes = getAttributes(options.codeAttributes);
+  const filterLanguages = getAttributes(options.filterLanguages);
 
   return function(str, language) {
     if(!language) {
@@ -16,6 +17,10 @@ module.exports = function (options = {}) {
     let split = language.split("/");
     if( split.length ) {
       language = split.shift();
+    }
+
+    if(filterLanguages.includes(language)) {
+      return `<pre class="${language} language-filtered no-highlight">${preAttributes}>${str}</pre>`;
     }
 
     let html;


### PR DESCRIPTION
# Short:
Added an option to skip language highlighting.

# Reason:
While working on an internal documentation system, we came across an issue with mermaid-graph rendering and language highlighting. We wanted highlighting for the code examples, but the mermaid graphs should be painted. 
There was no easy way to achieve this, through editing the Prism configuration, so I added an option to filter out specific languages from being rendered out.

# Solution:
Additional optional setting `languageFilter´. 
Default assignment is an empty array, so it will not impact running Installations. This change should be fully backwards compatible.
In the highlighting modules (HighlightPairedShortcode, markdownSyntaxHighlightOption) the language will be checked before any linting, or reading action. It checks if the language is included in the option array. If it is a plain "<pre>" will be returned with the language as class and any additional preAttributes set as option.