### PR TITLE
Add an option to ignore invalid languages. Fixes #70

### DIFF
--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -13,7 +13,16 @@ module.exports = function (content, language, highlightNumbers, options = {}) {
   if( language === "text" ) {
     highlightedContent = content;
   } else {
-    highlightedContent = Prism.highlight(content, PrismLoader(language), language);
+    let loader = PrismLoader(language, options)
+    if( !loader ) {
+      if (options.ignoreInvalidLanguages == "md") {
+        return content;
+      }
+
+      highlightedContent = content;
+    } else {
+      highlightedContent = Prism.highlight(content, loader, language);
+    }
   }
 
   let group = new HighlightLinesGroup(highlightNumbers);

--- a/src/PrismLoader.js
+++ b/src/PrismLoader.js
@@ -5,7 +5,7 @@ PrismLoader.silent = true;
 
 const PrismAlias = require("./PrismNormalizeAlias");
 
-module.exports = function(language) {
+module.exports = function(language, options = {}) {
   let diffRemovedRawName = language;
   if(language.startsWith("diff-")) {
     diffRemovedRawName = language.substr("diff-".length);
@@ -17,7 +17,11 @@ module.exports = function(language) {
     PrismLoader(aliasedName);
   }
   if(!Prism.languages[ aliasedName ]) {
-    throw new Error(`"${language}" is not a valid Prism.js language for eleventy-plugin-syntaxhighlight`);
+    if (options.ignoreInvalidLanguages) {
+      return null;
+    } else {
+      throw new Error(`"${language}" is not a valid Prism.js language for eleventy-plugin-syntaxhighlight`);
+    }
   }
 
   if(!language.startsWith("diff-")) {

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -20,7 +20,16 @@ module.exports = function (options = {}) {
     if(language === "text") {
       html = str;
     } else {
-      html = Prism.highlight(str, PrismLoader(language), language);
+      let loader = PrismLoader(language, options)
+      if(!loader) {
+        if (options.ignoreInvalidLanguages == "md") {
+          return str;
+        }
+        
+        html = str;
+      } else {
+        html = Prism.highlight(str, loader, language);
+      }
     }
 
     let hasHighlightNumbers = split.length > 0;

--- a/test/HighlightPairedShortcodeTest.js
+++ b/test/HighlightPairedShortcodeTest.js
@@ -91,6 +91,13 @@ test("Test loader invalid language", async t => {
   });
 });
 
+test("Test loader invalid language with ignore", async t => {
+  let src = `hello
+hello`
+  t.is(await HighlightPairedShortcode(src, "asldkjflksdaj", "", { ignoreInvalidLanguages: "html" }), `<pre class="language-asldkjflksdaj"><code class="language-asldkjflksdaj">hello<br>hello</code></pre>`);  
+  t.is(await HighlightPairedShortcode(src, "asldkjflksdaj", "", { ignoreInvalidLanguages: "md" }), src);  
+});
+
 test("Trim content option (defaults true)", async t => {
   t.is(await HighlightPairedShortcode(` alert();
 alert(); `, "js", "", {}), `<pre class="language-js"><code class="language-js"><span class="token function">alert</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">;</span><br><span class="token function">alert</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>`);

--- a/test/MarkdownHighlightTest.js
+++ b/test/MarkdownHighlightTest.js
@@ -58,6 +58,36 @@ test("Test Nunjucks Alias", t => {
 \`\`\``).trim(), `<pre class="language-nunjucks"><code class="language-nunjucks"><span class="token delimiter punctuation">{%</span> <span class="token tag keyword">raw</span> <span class="token operator">%</span><span class="token punctuation">}</span><span class="token variable">hello</span><span class="token punctuation">{</span><span class="token operator">%</span> <span class="token variable">endraw</span> <span class="token operator">%</span><span class="token punctuation">}</span></code></pre>`);
 });
 
+test("Test loader invalid language", t => {
+  let mdLib = md();
+  mdLib.set({
+    highlight: markdownPrismJsOptions()
+  });
+  t.throws(() => {
+    mdLib.render(`\`\`\`asldkjflksdaj
+hello
+\`\`\``);
+  });
+});
+
+test("Test loader invalid language with ignore", t => {
+  let src = `\`\`\`asldkjflksdaj
+hello
+\`\`\``;
+
+  let mdLib = md();
+  mdLib.set({
+    highlight: markdownPrismJsOptions({ ignoreInvalidLanguages: "html" })
+  });
+  t.is(mdLib.render(src).trim(), `<pre class="language-asldkjflksdaj"><code class="language-asldkjflksdaj">hello</code></pre>`);
+  
+  mdLib = md();
+  mdLib.set({
+    highlight: markdownPrismJsOptions({ ignoreInvalidLanguages: "md" })
+  });
+  t.is(mdLib.render(src).trim(), `<pre><code class="language-asldkjflksdaj">hello
+</code></pre>`);
+});
 
 // test("Test Markdown Highlighter Block Comment", t => {
 //   let mdLib = md();


### PR DESCRIPTION
In order to support both use-cases described in the issue, I've added an option called: `ignoreInvalidLanguages`.
This option can take take one of two values:

- `html` - Fixing the original use-case: Generate the same HTML as if the language was recognized, but has no special highlighting (similar to the `text` language)
- `md` - Keep the default markdown processing.

The difference in the output between the two options can also be seen in the newly added tests.