### PR TITLE
Add option to load languages explicitly

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,55 +1,60 @@
 const pkg = require("./package.json");
 const Prism = require("prismjs");
+const PrismLoader = require("./src/PrismLoader");
 const hasTemplateFormat = require("./src/hasTemplateFormat");
 const HighlightPairedShortcode = require("./src/HighlightPairedShortcode");
 const LiquidHighlightTag = require("./src/LiquidHighlightTag");
 const markdownPrismJs = require("./src/markdownSyntaxHighlightOptions");
 
-module.exports = {
-  initArguments: { Prism },
-  configFunction: function(eleventyConfig, options = {}) {
-    try {
-      eleventyConfig.versionCheck(pkg["11ty"].compatibility);
-    } catch(e) {
-      console.log( `WARN: Eleventy Plugin (${pkg.name}) Compatibility: ${e.message}` );
-    }
+module.exports = function(eleventyConfig, options){
+  try {
+    eleventyConfig.versionCheck(pkg["11ty"].compatibility);
+  } catch(e) {
+    console.log( `WARN: Eleventy Plugin (${pkg.name}) Compatibility: ${e.message}` );
+  }
+  options = Object.assign({
+    init: function({Prism}){},
+    lineSeparator: "\n",
+    errorOnInvalidLanguage: false,
+    alwaysWrapLineHighlights: false,
+    preAttributes: {},
+    codeAttributes: {},
+    languages: [],
+  }, options);
 
-    options = Object.assign({
-      lineSeparator: "\n",
-      errorOnInvalidLanguage: false,
-      alwaysWrapLineHighlights: false,
-      preAttributes: {},
-      codeAttributes: {}
-    }, options);
+  for(const language of options.languages){
+    PrismLoader(language)
+  }
 
-    if( hasTemplateFormat(options.templateFormats, "liquid") ) {
-      eleventyConfig.addLiquidTag("highlight", (liquidEngine) => {
-        // {% highlight js 0 2 %}
-        let highlight = new LiquidHighlightTag(liquidEngine);
-        return highlight.getObject(options);
-      });
-    }
-
-    if( hasTemplateFormat(options.templateFormats, "njk") ) {
-      eleventyConfig.addPairedNunjucksShortcode("highlight", (content, args) => {
-        // {% highlight "js 0 2-3" %}
-        let [language, ...highlightNumbers] = args.split(" ");
-        return HighlightPairedShortcode(content, language, highlightNumbers.join(" "), options);
-      });
-    }
-
-    if( hasTemplateFormat(options.templateFormats, "md") ) {
-      // ```js/0,2-3
-      eleventyConfig.addMarkdownHighlighter(markdownPrismJs(options));
-    }
-
-    // we need to add this as many template languages (Vue, WebC) rely on JavaScript functions (not just 11ty.js)
-    eleventyConfig.addJavaScriptFunction("highlight", (language, content, highlight1, highlight2) => {
-      let highlightLines = [highlight1, highlight2].filter(entry => entry).join(" ");
-      let result = HighlightPairedShortcode(content, language, highlightLines, options);
-      return result;
+  if( hasTemplateFormat(options.templateFormats, "liquid") ) {
+    eleventyConfig.addLiquidTag("highlight", (liquidEngine) => {
+      // {% highlight js 0 2 %}
+      let highlight = new LiquidHighlightTag(liquidEngine);
+      return highlight.getObject(options);
     });
   }
+
+  if( hasTemplateFormat(options.templateFormats, "njk") ) {
+    eleventyConfig.addPairedNunjucksShortcode("highlight", (content, args) => {
+      // {% highlight "js 0 2-3" %}
+      let [language, ...highlightNumbers] = args.split(" ");
+      return HighlightPairedShortcode(content, language, highlightNumbers.join(" "), options);
+    });
+  }
+
+  if( hasTemplateFormat(options.templateFormats, "md") ) {
+    // ```js/0,2-3
+    eleventyConfig.addMarkdownHighlighter(markdownPrismJs(options));
+  }
+
+  // we need to add this as many template languages (Vue, WebC) rely on JavaScript functions (not just 11ty.js)
+  eleventyConfig.addJavaScriptFunction("highlight", (language, content, highlight1, highlight2) => {
+    let highlightLines = [highlight1, highlight2].filter(entry => entry).join(" ");
+    let result = HighlightPairedShortcode(content, language, highlightLines, options);
+    return result;
+  });
+
+  options.init({Prism})
 };
 
 module.exports.pairedShortcode = HighlightPairedShortcode;


### PR DESCRIPTION
Resolves https://github.com/11ty/eleventy-plugin-syntaxhighlight/issues/47.

Adds a `languages` option to force-load languages before the `init` callback. Minor restructuring has been done to get the plugin in functional format, in order to allow for the `init` callback to run _after_ the loading of the languages.

Example usage in an `.eleventy.js` config file:

```js
export default function(eleventyConfig){
	eleventyConfig.addPlugin(SyntaxHighlight, {
		languages: ['css-extras', 'ruby'],
		init: function({Prism}){
			// do stuff with Prism.languages.ruby…
		}
	})
};
```

PS: The diff looks rather large due to an indentation change; please toggle "hide whitespace" to see the actual changes.