### PR TITLE
Fix diff-{language} highlighting #94

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "environmentVariables": {},
     "failFast": false,
     "files": [
-      "./test/*.js"
+      "./test/*.js",
+      "./test/*.mjs"
     ]
   }
 }

--- a/src/PrismLoader.js
+++ b/src/PrismLoader.js
@@ -3,7 +3,7 @@ const PrismLoader = require("prismjs/components/index.js");
 // Avoid "Language does not exist: " console logs
 PrismLoader.silent = true;
 
-const PrismDiff = require("prismjs/components/prism-diff.js");
+require("prismjs/components/prism-diff.js");
 
 // Load diff-highlight plugin
 require("prismjs/plugins/diff-highlight/prism-diff-highlight");
@@ -36,7 +36,7 @@ module.exports = function(language, options = {}) {
   // Store into with aliased keys
   //   ts -> diff-typescript
   //   js -> diff-javascript
-  Prism.languages[ fullLanguageName ] = PrismDiff;
+  Prism.languages[ fullLanguageName ] = Prism.languages.diff;
 
   return Prism.languages[ fullLanguageName ];
 };

--- a/test/JavaScriptFunctionTest.mjs
+++ b/test/JavaScriptFunctionTest.mjs
@@ -20,6 +20,6 @@ test("JavaScript Function Diff #76", async t => {
 
   t.is(json.length, 1);
   let rendered = json[0].content;
-	t.is(`<pre class="language-diff"><code class="language-diff"><span class="token deleted-sign deleted"><span class="token prefix deleted">-</span><span class="token line">var test;</span></span></code></pre>
+	t.is(`<pre class="language-diff"><code class="language-diff"><span class="token deleted-sign deleted"><span class="token prefix deleted">-</span>var test;</span></code></pre>
 <pre class="language-diff-js"><code class="language-diff-js"><span class="token deleted-sign deleted language-js"><span class="token prefix deleted">-</span><span class="token keyword">var</span> test<span class="token punctuation">;</span></span></code></pre>`, rendered);
 });


### PR DESCRIPTION
References:
- https://github.com/11ty/eleventy-plugin-syntaxhighlight/issues/94
- https://github.com/11ty/eleventy-base-blog/issues/211

Basically, the diff-{language} identifier wasn't working. 

Looks like the problem was in the `PrismLoader.js` where we set `Prism.languages[ fullLanguageName ]` to `PrismDiff` which will always be an empty object, since `prism-diff.js` contains just a IIFE that doesn't return anything and only add the `diff` loader object inside `Prism.languages` (global object).

So, I've set `Prism.languages[ fullLanguageName ]` to `Prism.languages.diff` which returns the proper grammar that is received in `markdownSyntaxHighlightOptions.js` to call the `Prism.highlight(str, loader, language)` method.

### Note:
- I think we don't even have to set `Prism.languages[ fullLanguageName ]` since it will be created for us in the hooks that are run when calling the `Prism.highlight()` method. But I've refrained from directly returning the `diff` loader speculating it could have another utility and I didn't want to break things.
- There were existing test cases that covered this scenario but I think they got omitted since they had the `.mjs` file extension. Having these cases could've prevented the bug from getting in.
- Lastly I think the test files could use some refactoring. I'm interested in doing that. Do let me know if you want me to do that!